### PR TITLE
Fix: Adapt to new Tickera backend plugin API response format (#16)

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,7 +43,10 @@ def main():
                                 tc_paid_date = meta.get('value')
                                 break
                         order_tickets = fetch_ticket_data(session, url, order_id, tc_paid_date)
-                        future_to_tickets = {executor.submit(print_ticket, session, url, ticket['ticket_id'], tc_paid_date, ticket['hash'], ticket['ticket_template_POS'], printer): ticket for ticket in order_tickets['data']}
+                        if order_tickets.get('status') != 200:
+                            logger.error(f"Ticket-Daten für Bestellung {order_id} konnten nicht abgerufen werden: {order_tickets.get('message', 'Unbekannter Fehler')}")
+                            continue
+                        future_to_tickets = {executor.submit(print_ticket, session, url, ticket['ticket_id'], ticket['tc_order_key'], ticket['hash'], ticket['ticket_template_POS'], printer): ticket for ticket in order_tickets['data']}
                         known_order_ids.add(order_id)
                 else:
                     logger.info("Keine neuen Bestellungen gefunden.")


### PR DESCRIPTION
## Summary
- Use `tc_order_key` from ticket data as `order_key` for PDF downloads instead of `_tc_paid_date`
- Validate API response `status == 200` before processing tickets; log error and skip order on failure

## Test plan
- [ ] Run `python main.py` with `.env` pointing to the updated backend plugin
- [ ] Confirm tickets are fetched and PDFs printed successfully
- [ ] Confirm non-200 responses are logged and the polling loop continues without crashing

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)