### PR TITLE
Fix: break → continue to avoid skipping new orders (#18)

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ def main():
                     for order in orders:
                         order_id = order['id']
                         if order_id in known_order_ids:
-                            break
+                            continue
                         tc_paid_date = None
                         for meta in order.get('meta_data', []):
                             if meta.get('key') == '_tc_paid_date':


### PR DESCRIPTION
## Summary
- Fixes \`break\` → \`continue\` on \`main.py:39\` so the order loop skips known orders instead of aborting entirely
- Prevents new orders from being silently dropped when they appear after a known order in the API response

## Related Issues
- Closes #18
- Root cause of #11 (concurrent orders not printing)

## Test plan
- [ ] Place two orders in quick succession and verify both tickets are printed
- [ ] Confirm that already-known orders are skipped without interrupting processing of subsequent new orders

🤖 Generated with [Claude Code](https://claude.com/claude-code)