### PR TITLE
Fix non-thread-safe shared requests.Session in parallel ticket printing

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ def main():
                         if order_tickets.get('status') != 200:
                             logger.error(f"Ticket-Daten für Bestellung {order_id} konnten nicht abgerufen werden: {order_tickets.get('message', 'Unbekannter Fehler')}")
                             continue
-                        future_to_tickets = {executor.submit(print_ticket, session, url, ticket['ticket_id'], ticket['tc_order_key'], ticket['hash'], ticket['ticket_template_POS'], printer): ticket for ticket in order_tickets['data']}
+                        future_to_tickets = {executor.submit(print_ticket, url, ticket['ticket_id'], ticket['tc_order_key'], ticket['hash'], ticket['ticket_template_POS'], printer): ticket for ticket in order_tickets['data']}
                         known_order_ids.add(order_id)
                 else:
                     logger.info("Keine neuen Bestellungen gefunden.")

--- a/src/tc.py
+++ b/src/tc.py
@@ -26,15 +26,15 @@ def fetch_ticket_data(session, url, order_id, order_key):
     else:
         return {"status": str(response.status_code), "message": "Request failed."}
 
-def print_ticket(session, url, ticket_id, order_key, hash, template_id, printer_name):
+def print_ticket(url, ticket_id, order_key, nonce, template_id, printer_name):
     params = {
         "download_ticket": ticket_id,
         "order_key": order_key,
-        "nonce": hash,
+        "nonce": nonce,
         "template_id": template_id
     }
 
-    response = session.get(url, params=params)
+    response = requests.get(url, params=params, headers={"User-Agent": "Mozilla/5.0"})
     if response.status_code == 200:
         with tempfile.NamedTemporaryFile(suffix='.pdf', delete=False) as fp:
             fp.write(response.content)


### PR DESCRIPTION
## Summary
- `print_ticket()` no longer receives the shared `requests.Session` — each worker thread now calls `requests.get()` directly, which is thread-safe
- Removes the root cause of concurrent ticket download failures when multiple tickets are processed in parallel
- Renames the `hash` parameter to `nonce` to avoid shadowing the Python builtin

## Related Issues
Closes #19
Related: #11 (concurrent orders not printing — likely symptom of this bug)

## Test plan
- [ ] Place a single order with multiple tickets and verify all tickets print
- [ ] Place two or more orders simultaneously and verify all tickets from both orders print
- [ ] Check logs for no HTTP errors from the standalone `requests.get()` calls
- [ ] Verify `fetch_ticket_data()` (main-thread session) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)