### PR TITLE
Fix WooCommerce API client singleton and exclude serialization

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from src.tc import fetch_ticket_data, print_ticket, create_session
 from src.printing import get_default_printer
 from dotenv import load_dotenv
 from src.logging_config import setup_logging
+from woocommerce import API
 import logging, concurrent.futures, os
 
 logger = setup_logging(__name__,logging.DEBUG)
@@ -24,14 +25,23 @@ def main():
     if not url or not consumer_key or not consumer_secret:
         logger.error("URL, Consumer Key oder Consumer Secret sind nicht gesetzt.")
         return
-    
+
+    wcapi = API(
+        url=url,
+        consumer_key=consumer_key,
+        consumer_secret=consumer_secret,
+        version="wc/v3",
+        wp_api=True,
+        order='asc',
+    )
+
     with concurrent.futures.ThreadPoolExecutor(max_workers=12) as executor:
         try:
             while True:  # Endlosschleife für kontinuierlichen Betrieb
                 if session is None:
                     session = create_session()
 
-                orders = get_new_orders(url, consumer_key, consumer_secret, time_threshold, order_state, customer_id, known_order_ids)
+                orders = get_new_orders(wcapi, time_threshold, order_state, customer_id, known_order_ids)
                 if orders:
                     for order in orders:
                         order_id = order['id']

--- a/src/api.py
+++ b/src/api.py
@@ -1,40 +1,28 @@
 ﻿import logging
-from woocommerce import API
 from src.logging_config import setup_logging
 
 logger = setup_logging(__name__,logging.DEBUG)
 
-def get_new_orders(url, consumer_key, consumer_secret, after, order_state="completed", customer_id=None, known_orders=None):
+def get_new_orders(wcapi, after, order_state="completed", customer_id=None, known_orders=None):
     """
     Funktion zum Abrufen neuer Bestellungen eines bestimmten Typs von WooCommerce.
-    
+
     Args:
-    - url (str): Die URL zur WooCommerce API.
-    - consumer_key (str): Der Consumer Key für den API-Zugriff.
-    - consumer_secret (str): Der Consumer Secret für den API-Zugriff.
+    - wcapi: Ein bereits initialisierter WooCommerce API-Client.
     - order_state (str): Gibt den Status der Bestellungen an, die zurückgegeben werden sollen. Standard ist 'completed'.
     - customer_id (int, optional): Die ID des Kunden, dessen Bestellungen abgerufen werden sollen. Default ist None.
     - after (str): ISO8601-Datum, um Bestellungen ab einem bestimmten Zeitpunkt abzurufen.
     - known_orders (set, optional): Set von bekannten Bestellungs-IDs, die ausgeschlossen werden sollen. Default ist None.
-    
+
     Returns:
     - list: Eine Liste der gefundenen Bestellungen.
     """
-    wcapi = API(
-        url=url,
-        consumer_key=consumer_key,
-        consumer_secret=consumer_secret,
-        version="wc/v3",
-        wp_api=True,
-        order='asc',
-    )
-
     params = {"status": order_state, "after": after}
     if customer_id is not None:
         params["customer"] = customer_id
 
     if known_orders is not None:
-        params["exclude"] = known_orders
+        params["exclude"] = ",".join(str(oid) for oid in known_orders)
 
     try:
         response = wcapi.get("orders", params=params)


### PR DESCRIPTION
## Summary
- Move `WooCommerce.API` client creation from `get_new_orders()` into `main()` — client is now instantiated once at startup and reused across all polling iterations
- Update `get_new_orders()` signature: replace `url`/`consumer_key`/`consumer_secret` params with a single pre-built `wcapi` client
- Serialize `known_orders` set to a comma-separated string (`",".join(str(oid) for oid in known_orders)`) before passing as the `exclude` parameter, as required by the WooCommerce REST API

## Test plan
- [ ] Verify import: `python3 -c "from src.api import get_new_orders; print('ok')"`
- [ ] Start the application with valid `.env` credentials and confirm polling works without errors
- [ ] Confirm orders in `known_order_ids` are correctly excluded from subsequent API responses

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)